### PR TITLE
Don't interpret .frag as js

### DIFF
--- a/src/prettier_plugins_builtin.ts
+++ b/src/prettier_plugins_builtin.ts
@@ -320,7 +320,6 @@ const languages = [
       ".cjs",
       ".es",
       ".es6",
-      ".frag",
       ".gs",
       ".jake",
       ".javascript",


### PR DESCRIPTION
The `.frag` file extension is commonly used for glsl shaders, so parsing as javascript gives spurious errors