### PR TITLE
fix(deps): support pre-release as allowed peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "typescript": "^5.4.5"
       },
       "peerDependencies": {
-        "prettier": "^3.1.0 || ^4.0.0"
+        "prettier": "^3.1.0 || ^4.0.0-alpha"
       }
     },
     "node_modules/@iarna/toml": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "prettier": "^3.1.0 || ^4.0.0"
+    "prettier": "^3.1.0 || ^4.0.0-alpha"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
## The problem
* npm doesnt take pre-release as candidate versions so `prettier@4.0.0-alpha.9` isn't a valid version for `^3.1.0 || ^4.0.0`
* As a result without using npm `--legacy-peer-deps`, we can't use version 4

![Capture d’écran du 2024-08-20 11-22-35](https://github.com/user-attachments/assets/eacd01a5-d8ab-4a9a-be64-da1f600eb903)

## Suggested solution is to add pre-release allowed in peerDeps

```javascript
require('semver').satisfies('4.0.0-alpha.9', '^3.1.0 || ^4.0.0'); // return false
require('semver').satisfies('4.0.0-alpha.9', '^3.1.0 || ^4.0.0-alpha'); // return true
require('semver').satisfies('4.0.12', '^3.1.0 || ^4.0.0-alpha'); // return true
require('semver').satisfies('4.0.0-beta.1', '^3.1.0 || ^4.0.0-alpha'); // return true
require('semver').satisfies('4.0.3-alpha.2', '^3.1.0 || ^4.0.0-alpha'); // return false
```

## Workaround

* Use `npm install --save-dev prettier@4.0.0-alpha.9 --legacy-peer-deps`

![Capture d’écran du 2024-08-20 11-28-26](https://github.com/user-attachments/assets/3f1f20fa-2a24-4b01-9b09-b0f535a6a0b3)


PS: if this is the intended behavior please close this PR