### PR TITLE
test: restore previously ignored fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Build & Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run compile
+
+      - name: Test
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@
 .Trashes
 Thumbs.db
 
-dist
-node_modules
+/dist
+/node_modules

--- a/test/__fixtures__/with-node-modules/nested/node_modules/node-module.js
+++ b/test/__fixtures__/with-node-modules/nested/node_modules/node-module.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+'use strict';

--- a/test/__fixtures__/with-node-modules/node_modules/node-module.js
+++ b/test/__fixtures__/with-node-modules/node_modules/node-module.js
@@ -1,0 +1,2 @@
+/* eslint-disable */
+'use strict';


### PR DESCRIPTION
Our `gitignore` was ignoring all `node_modules`, including those in fixture data. This was leading to the tests failing as their snapshots would mismatch.

We only actually need to ignore the root `/node_modules` since we're not n a monorepo (for now at least).

Since these now pass, this also enables a new CI workflow which runs tests.