### PR TITLE
test: launch CLI lazily in tests

### DIFF
--- a/test/__fixtures__/ignore-unknown/.prettierignore
+++ b/test/__fixtures__/ignore-unknown/.prettierignore
@@ -1,0 +1,1 @@
+ignored.js

--- a/test/__fixtures__/ignore-unknown/.prettierrc
+++ b/test/__fixtures__/ignore-unknown/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": "*.as-js-file",
+      "options": {
+        "parser": "babel"
+      }
+    }
+  ]
+}

--- a/test/__fixtures__/ignore-unknown/javascript.js
+++ b/test/__fixtures__/ignore-unknown/javascript.js
@@ -1,0 +1,1 @@
+const foo=        "bar";

--- a/test/__fixtures__/ignore-unknown/override.as-js-file
+++ b/test/__fixtures__/ignore-unknown/override.as-js-file
@@ -1,0 +1,1 @@
+const foo=        "bar";

--- a/test/__fixtures__/ignore-unknown/unkown-file-extension.unknown
+++ b/test/__fixtures__/ignore-unknown/unkown-file-extension.unknown
@@ -1,0 +1,1 @@
+PRETTIER

--- a/test/__fixtures__/ignore-unknown/unkown-filename
+++ b/test/__fixtures__/ignore-unknown/unkown-filename
@@ -1,0 +1,1 @@
+PRETTIER

--- a/test/__tests__/__snapshots__/ignore-unknown.js.snap
+++ b/test/__tests__/__snapshots__/ignore-unknown.js.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ignored file (stderr) 1`] = `""`;
+
+exports[`Ignored file (stdout) 1`] = `""`;
+
+exports[`Ignored file (write) 1`] = `[]`;
+
+exports[`None exist file (stderr) 1`] = `"[error] No files matching the given patterns were found"`;
+
+exports[`None exist file (stdout) 1`] = `""`;
+
+exports[`None exist file (write) 1`] = `[]`;
+
+exports[`Not matching pattern (stderr) 1`] = `"[error] No files matching the given patterns were found"`;
+
+exports[`Not matching pattern (stdout) 1`] = `""`;
+
+exports[`Not matching pattern (write) 1`] = `[]`;
+
+exports[`ignore-unknown alias (stdout) 1`] = `
+"javascript.js
+override.as-js-file"
+`;
+
+exports[`ignore-unknown check (stderr) 1`] = `
+"[warn] javascript.js
+[warn] override.as-js-file
+[warn] Code style issues found in 2 files. Run Prettier with --write to fix."
+`;
+
+exports[`ignore-unknown check (stdout) 1`] = `"Checking formatting..."`;
+
+exports[`ignore-unknown check (write) 1`] = `[]`;
+
+exports[`ignore-unknown dir (stdout) 1`] = `
+"javascript.js
+override.as-js-file"
+`;
+
+exports[`ignore-unknown pattern (stdout) 1`] = `
+"javascript.js
+override.as-js-file"
+`;

--- a/test/__tests__/ignore-unknown.js
+++ b/test/__tests__/ignore-unknown.js
@@ -1,0 +1,75 @@
+import { runCli } from "../utils";
+
+describe("ignore-unknown dir", () => {
+  runCli("ignore-unknown", [
+    ".",
+    "--ignore-unknown",
+    "--list-different",
+  ]).test({
+    status: "non-zero",
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("ignore-unknown alias", () => {
+  runCli("ignore-unknown", [
+    ".",
+    "-u",
+    "--list-different",
+  ]).test({
+    status: "non-zero",
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("ignore-unknown pattern", () => {
+  runCli("ignore-unknown", [
+    "*",
+    "--ignore-unknown",
+    "--list-different",
+  ]).test({
+    status: "non-zero",
+    stderr: "",
+    write: [],
+  });
+});
+
+
+describe("ignore-unknown check", () => {
+  runCli("ignore-unknown", [
+    ".",
+    "--ignore-unknown",
+    "--check",
+  ]).test({
+    status: 1,
+  });
+});
+
+describe("None exist file", () => {
+  runCli("ignore-unknown", [
+    "non-exist-file",
+    "--ignore-unknown",
+  ]).test({
+    status: 1,
+  });
+});
+
+describe("Not matching pattern", () => {
+  runCli("ignore-unknown", [
+    "*.non-exist-pattern",
+    "--ignore-unknown",
+  ]).test({
+    status: 1,
+  });
+});
+
+describe("Ignored file", () => {
+  runCli("ignore-unknown", [
+    "ignored.js",
+    "--ignore-unknown",
+  ]).test({
+    status: 0,
+  });
+});


### PR DESCRIPTION
Launches the CLI only when a test runs instead of immediately.

This means tests will no longer interfere with each other.