### PR TITLE
test: migrate plugin-options tests

### DIFF
--- a/test/__fixtures__/plugin-options/config.json
+++ b/test/__fixtures__/plugin-options/config.json
@@ -1,0 +1,4 @@
+{
+    "plugins": ["./plugin.cjs"],
+    "fooOption": "baz"
+}

--- a/test/__fixtures__/plugin-options/plugin.cjs
+++ b/test/__fixtures__/plugin-options/plugin.cjs
@@ -1,0 +1,41 @@
+"use strict";
+
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"],
+      since: "1.0.0",
+    },
+  ],
+  options: {
+    fooOption: {
+      type: "choice",
+      default: "bar",
+      description: "foo description",
+      choices: [
+        {
+          value: "bar",
+          description: "bar description",
+        },
+        {
+          value: "baz",
+          description: "baz description",
+        },
+      ],
+    },
+  },
+  parsers: {
+    "foo-parser": {
+      parse: (text) => ({ text }),
+      astFormat: "foo-ast",
+    },
+  },
+  printers: {
+    "foo-ast": {
+      print: (path, options) =>
+        options.fooOption ? `foo:${options.fooOption}` : path.getValue().text,
+    },
+  },
+};

--- a/test/__tests__/__snapshots__/plugin-options.js.snap
+++ b/test/__tests__/__snapshots__/plugin-options.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (stderr) 1`] = `""`;
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (stdout) 1`] = `
+"--parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
+
+  Which parser to use.
+
+Valid options:
+
+  flow             Flow
+  babel            JavaScript
+  babel-flow       Flow
+  babel-ts         TypeScript
+  typescript       TypeScript
+  acorn            JavaScript
+  espree           JavaScript
+  meriyah          JavaScript
+  css              CSS
+  less             Less
+  scss             SCSS
+  json             JSON
+  json5            JSON5
+  jsonc            JSON with Comments
+  json-stringify   JSON.stringify
+  graphql          GraphQL
+  markdown         Markdown
+  mdx              MDX
+  vue              Vue
+  yaml             YAML
+  glimmer          Ember / Handlebars
+  html             HTML
+  angular          Angular
+  lwc              Lightning Web Components
+  foo-parser       foo (plugin: ./plugin.cjs)"
+`;
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (write) 1`] = `[]`;
+
+exports[`show detailed external option with \`--help foo-option\` (stderr) 1`] = `""`;
+
+exports[`show detailed external option with \`--help foo-option\` (stdout) 1`] = `
+"--foo-option <bar|baz>
+
+  foo description
+
+Valid options:
+
+  bar   bar description
+  baz   baz description
+
+Default: bar"
+`;
+
+exports[`show detailed external option with \`--help foo-option\` (write) 1`] = `[]`;
+
+exports[`show external options with \`--help\` 1`] = `
+"    --parser <flow,babel,babel-flow,babel-ts,typescript,acorn,espree,meriyah,css,less,scss,json,json5,json-stringify,graphql,markdown,mdx,vue,yaml,glimmer,html,angular,lwc,foo-parser>
+    --foo-option <bar|baz>    foo description
+                              Defaults to "bar""
+`;

--- a/test/__tests__/plugin-options.js
+++ b/test/__tests__/plugin-options.js
@@ -1,0 +1,68 @@
+import { runCli } from "../utils";
+
+test("show external options with `--help`", async () => {
+  const originalStdout = await runCli("plugin-options", ["--help"]).stdout;
+  const pluggedStdout = await runCli("plugin-options", [
+    "--help",
+    "--plugin=./plugin.cjs",
+  ]).stdout;
+
+  const originalLines = originalStdout.split("\n");
+  const pluggedLines = pluggedStdout.split("\n");
+  const differentLines = pluggedLines.filter((line) =>
+    !originalLines.includes(line));
+  expect(differentLines.join("\n")).toMatchSnapshot();
+});
+
+// Note (43081j): we don't currently support `--help {option}`
+describe.skip("show detailed external option with `--help foo-option`", () => {
+  runCli("plugin-options", [
+    "--plugin=./plugin.cjs",
+    "--help",
+    "foo-option",
+  ]).test({
+    status: 0,
+  });
+});
+
+// Note (43081j): we don't currently support `--help {option}`
+describe.skip("include plugin's parsers to the values of the `parser` option`", () => {
+  runCli("plugin-options", ["--plugin=./plugin.cjs", "--help", "parser"]).test(
+    {
+      status: 0,
+    },
+  );
+});
+
+describe("external options from CLI should work", () => {
+  runCli(
+    "plugin-options",
+    [
+      "--plugin=./plugin.cjs",
+      "--stdin-filepath",
+      "example.foo",
+      "--foo-option",
+      "baz",
+    ],
+    { input: "hello-world" },
+  ).test({
+    stdout: "foo:baz",
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});
+
+// TODO (43081j): re-enable this once #21 is fixed
+describe.skip("external options from config file should work", () => {
+  runCli(
+    "plugin-options",
+    ["--config-path=./config.json", "--stdin-filepath", "example.foo"],
+    { input: "hello-world" },
+  ).test({
+    stdout: "foo:baz",
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});


### PR DESCRIPTION
Copies the `plugin-option` tests from prettier.

Note that these will need updating once #39 and #21 are fixed.