### PR TITLE
Replace `@iarna/toml` with `smol-toml`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@iarna/toml": "^2.2.5",
         "atomically": "^2.0.3",
         "fast-ignore": "^1.1.3",
         "find-up-json": "^2.0.4",
@@ -23,6 +22,7 @@
         "lomemo": "^1.0.0",
         "pioppo": "^1.2.0",
         "promise-resolve-timeout": "^2.0.0",
+        "smol-toml": "^1.3.1",
         "specialist": "^1.4.5",
         "tiny-editorconfig": "^1.0.0",
         "tiny-jsonc": "^1.0.1",
@@ -619,11 +619,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "node_modules/@iarna/toml": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -5494,6 +5489,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
+      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6535,11 +6541,6 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
-    },
-    "@iarna/toml": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-      "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -10337,6 +10338,11 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "smol-toml": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
+      "integrity": "sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ=="
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "prettier": "^3.1.0 || ^4.0.0-alpha"
   },
   "dependencies": {
-    "@iarna/toml": "^2.2.5",
     "atomically": "^2.0.3",
     "fast-ignore": "^1.1.3",
     "find-up-json": "^2.0.4",
@@ -49,6 +48,7 @@
     "lomemo": "^1.0.0",
     "pioppo": "^1.2.0",
     "promise-resolve-timeout": "^2.0.0",
+    "smol-toml": "^1.3.1",
     "specialist": "^1.4.5",
     "tiny-editorconfig": "^1.0.0",
     "tiny-jsonc": "^1.0.1",

--- a/src/config_prettier.ts
+++ b/src/config_prettier.ts
@@ -51,8 +51,8 @@ const Loaders = {
   },
   toml: async (filePath: string): Promise<unknown> => {
     const fileContent = fs.readFileSync(filePath, "utf8");
-    const TOML = (await import("@iarna/toml")).default;
-    return TOML.parse(fileContent);
+    const toml = await import("smol-toml");
+    return toml.parse(fileContent);
   },
   yaml: async (filePath: string): Promise<unknown> => {
     const yaml = (await import("js-yaml")).default;


### PR DESCRIPTION
Same reason as https://github.com/prettier/prettier/pull/16497

I didn't see tests in https://github.com/prettier/prettier-cli/commit/fc758043498b48ab999c1df976558ffafa078302, so I manually tested locally, it can successfully load `.toml` config file.