### PR TITLE
test: migrate `write` tests

### DIFF
--- a/test/__tests__/__snapshots__/write.js.snap
+++ b/test/__tests__/__snapshots__/write.js.snap
@@ -2,7 +2,7 @@
 
 exports[`do not write file with --write + formatted file (stderr) 1`] = `""`;
 
-exports[`do not write file with --write + formatted file (stdout) 1`] = `"formatted.js 0ms (unchanged)"`;
+exports[`do not write file with --write + formatted file (stdout) 1`] = `""`;
 
 exports[`do not write file with --write + invalid file (stderr) 1`] = `
 "[error] invalid.js: SyntaxError: Unexpected token (1:17)
@@ -14,7 +14,7 @@ exports[`do not write file with --write + invalid file (stdout) 1`] = `""`;
 
 exports[`write file with --write + unformatted file (stderr) 1`] = `""`;
 
-exports[`write file with --write + unformatted file (stdout) 1`] = `"unformatted.js 0ms"`;
+exports[`write file with --write + unformatted file (stdout) 1`] = `"unformatted.js"`;
 
 exports[`write file with --write + unformatted file (write) 1`] = `
 [
@@ -28,7 +28,7 @@ exports[`write file with --write + unformatted file (write) 1`] = `
 
 exports[`write file with -w + unformatted file (stderr) 1`] = `""`;
 
-exports[`write file with -w + unformatted file (stdout) 1`] = `"unformatted.js 0ms"`;
+exports[`write file with -w + unformatted file (stdout) 1`] = `"unformatted.js"`;
 
 exports[`write file with -w + unformatted file (write) 1`] = `
 [

--- a/test/__tests__/write.js
+++ b/test/__tests__/write.js
@@ -1,40 +1,26 @@
 import { runCli } from "../utils";
 
-//TODO: Align the output for the following tests
-
-describe.skip("write file with --write + unformatted file", () => {
-  runCli("write", [
-    "--write",
-    "unformatted.js",
-  ]).test({
+describe("write file with --write + unformatted file", () => {
+  runCli("write", ["--write", "unformatted.js"]).test({
     status: 0,
   });
 });
 
-describe.skip("write file with -w + unformatted file", () => {
-  runCli("write", [
-    "-w",
-    "unformatted.js",
-  ]).test({
+describe("write file with -w + unformatted file", () => {
+  runCli("write", ["-w", "unformatted.js"]).test({
     status: 0,
   });
 });
 
-describe.skip("do not write file with --write + formatted file", () => {
-  runCli("write", [
-    "--write",
-    "formatted.js",
-  ]).test({
+describe("do not write file with --write + formatted file", () => {
+  runCli("write", ["--write", "formatted.js"]).test({
     write: [],
     status: 0,
   });
 });
 
-describe.skip("do not write file with --write + invalid file", () => {
-  runCli("write", [
-    "--write",
-    "invalid.js",
-  ]).test({
+describe("do not write file with --write + invalid file", () => {
+  runCli("write", ["--write", "invalid.js"]).test({
     write: [],
     status: "non-zero",
   });


### PR DESCRIPTION
Copies the `write` tests from prettier.

Notable differences:

- Unchanged files are still listed in the output in prettier, but not here (e.g. `foo.js (unchanged)`)
- Written files also log out the time taken in prettier (e.g. `foo.js 0ms`)