### PR TITLE
test: migrate `with-parser-inference` tests

### DIFF
--- a/test/__fixtures__/with-parser-inference/javascript.js
+++ b/test/__fixtures__/with-parser-inference/javascript.js
@@ -1,0 +1,2 @@
+/* JavaScript */
+"use strict";

--- a/test/__fixtures__/with-parser-inference/stylesheet.css
+++ b/test/__fixtures__/with-parser-inference/stylesheet.css
@@ -1,0 +1,4 @@
+/* Stylesheet */
+* {
+  outline: none;
+}

--- a/test/__tests__/__snapshots__/with-parser-inference.js.snap
+++ b/test/__tests__/__snapshots__/with-parser-inference.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`infers parser from filename (.prettierrc) (stdout) 1`] = `"{}"`;
+
+exports[`infers parser from filename (.stylelintrc YAML) (stdout) 1`] = `"extends: """`;
+
+exports[`infers parser from filename (.stylelintrc) (stdout) 1`] = `"{}"`;
+
+exports[`infers parser from filename (jakefile) (stdout) 1`] = `"let foo = (x = 1) => x;"`;
+
+exports[`infers parser from filename (lintstagedrc YAML) (stdout) 1`] = `
+""*":
+  - your-cmd"
+`;
+
+exports[`infers parser from filename (lintstagedrc) (stdout) 1`] = `"{ "*": "your-cmd" }"`;
+
+exports[`infers parser from filename (swcrc) (stdout) 1`] = `
+"{
+  "jsc": {
+    // Requires v1.2.50 or upper and requires target to be es2016 or upper.
+    "keepClassNames": false
+  }
+}"
+`;
+
+exports[`infers postcss parser (stderr) 1`] = `""`;
+
+exports[`infers postcss parser (stdout) 1`] = `
+"/* JavaScript */
+"use strict";
+/* Stylesheet */
+* {
+  outline: none;
+}"
+`;
+
+exports[`infers postcss parser (write) 1`] = `[]`;
+
+exports[`infers postcss parser with --check (stderr) 1`] = `""`;
+
+exports[`infers postcss parser with --check (stdout) 1`] = `
+"Checking formatting...
+All matched files use Prettier code style!"
+`;
+
+exports[`infers postcss parser with --check (write) 1`] = `[]`;
+
+exports[`infers postcss parser with --list-different (stderr) 1`] = `""`;
+
+exports[`infers postcss parser with --list-different (stdout) 1`] = `""`;
+
+exports[`infers postcss parser with --list-different (write) 1`] = `[]`;

--- a/test/__tests__/with-parser-inference.js
+++ b/test/__tests__/with-parser-inference.js
@@ -1,0 +1,121 @@
+import { runCli } from "../utils";
+
+describe("infers postcss parser", () => {
+  runCli("with-parser-inference", ["--end-of-line", "lf", "*"]).test({
+    status: 0,
+  });
+});
+
+describe("infers postcss parser with --check", () => {
+  runCli("with-parser-inference", ["--check", "*"]).test({
+    status: 0,
+  });
+});
+
+describe("infers postcss parser with --list-different", () => {
+  runCli("with-parser-inference", ["--list-different", "*"]).test({
+    status: 0,
+  });
+});
+
+describe("infers parser from filename (.prettierrc)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.prettierrc",
+  ], {
+    input: "  {   }  ",
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (.stylelintrc)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.stylelintrc",
+  ], {
+    input: "  {   }  ",
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (.stylelintrc YAML)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.stylelintrc",
+  ], {
+    input: "  extends:    ''  ",
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (jakefile)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/Jakefile",
+  ], {
+    input: "let foo = ( x = 1 ) => x",
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (swcrc)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.swcrc",
+  ], {
+    input:
+        /* indent */ `
+          {
+                      "jsc": {
+                    // Requires v1.2.50 or upper and requires target to be es2016 or upper.
+                        "keepClassNames": false
+                      }}
+        `,
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (lintstagedrc)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.lintstagedrc",
+  ], {
+    input: "  {  '*':   'your-cmd'  }  ",
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
+describe("infers parser from filename (lintstagedrc YAML)", () => {
+  runCli("with-parser-inference", [
+    "--stdin-filepath",
+    "x/y/.lintstagedrc",
+  ], {
+    input:
+        /* indent */ `
+          '*':
+                 - your-cmd
+        `,
+  }).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});


### PR DESCRIPTION
Copies the `with-parser-inference` tests from prettier.

No differences other than we use snapshots instead of calling the prettier library programmatically.