### PR TITLE
Add `jsonc` parser, remove support for `.prettierrc.jsonc`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "smol-toml": "^1.3.3",
         "specialist": "^1.4.5",
         "tiny-editorconfig": "^1.0.0",
-        "tiny-jsonc": "^1.0.2",
         "tiny-readdir": "^2.7.4",
         "tiny-readdir-glob": "^1.23.2",
         "tiny-spinner": "^2.0.5",
@@ -5784,11 +5783,6 @@
         "grammex": "^3.1.1"
       }
     },
-    "node_modules/tiny-jsonc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.2.tgz",
-      "integrity": "sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw=="
-    },
     "node_modules/tiny-levenshtein": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tiny-levenshtein/-/tiny-levenshtein-1.0.1.tgz",
@@ -10594,11 +10588,6 @@
           }
         }
       }
-    },
-    "tiny-jsonc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-jsonc/-/tiny-jsonc-1.0.2.tgz",
-      "integrity": "sha512-f5QDAfLq6zIVSyCZQZhhyl0QS6MvAyTxgz4X4x3+EoCktNWEYJ6PeoEA97fyb98njpBNNi88ybpD7m+BDFXaCw=="
     },
     "tiny-levenshtein": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "smol-toml": "^1.3.3",
     "specialist": "^1.4.5",
     "tiny-editorconfig": "^1.0.0",
-    "tiny-jsonc": "^1.0.2",
     "tiny-readdir": "^2.7.4",
     "tiny-readdir-glob": "^1.23.2",
     "tiny-spinner": "^2.0.5",

--- a/src/config_prettier.ts
+++ b/src/config_prettier.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
-import JSONC from "tiny-jsonc";
 import zeptomatch from "zeptomatch";
 import Known from "./known.js";
 import { fastJoinedPath, fastRelativeChildPath, getModulePath } from "./utils.js";
@@ -22,11 +21,6 @@ const Loaders = {
   json: async (filePath: string): Promise<unknown> => {
     const fileContent = fs.readFileSync(filePath, "utf8");
     const config = JSON.parse(fileContent);
-    return config;
-  },
-  jsonc: async (filePath: string): Promise<unknown> => {
-    const fileContent = fs.readFileSync(filePath, "utf8");
-    const config = JSONC.parse(fileContent);
     return config;
   },
   json5: async (filePath: string): Promise<unknown> => {
@@ -71,7 +65,6 @@ const File2Loader: Record<string, (filePath: string) => Promise<unknown>> = {
   ".prettierrc.yml": Loaders.yaml,
   ".prettierrc.yaml": Loaders.yaml,
   ".prettierrc.json": Loaders.json,
-  ".prettierrc.jsonc": Loaders.jsonc,
   ".prettierrc.json5": Loaders.json5,
   ".prettierrc.toml": Loaders.toml,
   ".prettierrc.js": Loaders.js,
@@ -87,7 +80,6 @@ const Ext2Loader: Record<string, (filePath: string) => Promise<unknown>> = {
   yml: Loaders.yaml,
   yaml: Loaders.yaml,
   json: Loaders.json,
-  jsonc: Loaders.jsonc,
   json5: Loaders.json5,
   toml: Loaders.toml,
   js: Loaders.js,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,6 +21,7 @@ const DEFAULT_PARSERS = [
   "scss",
   "json",
   "json5",
+  "jsonc",
   "json-stringify",
   "graphql",
   "markdown",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ type FormatOptions = {
   insertPragma?: boolean;
   jsxSingleQuote?: boolean;
   objectWrap?: "preserve" | "collapse";
-  parser?: "flow" | "babel" | "babel-flow" | "babel-ts" | "typescript" | "acorn" | "espree" | "meriyah" | "css" | "less" | "scss" | "json" | "json5" | "json-stringify" | "graphql" | "markdown" | "mdx" | "vue" | "yaml" | "glimmer" | "html" | "angular" | "lwc"; // prettier-ignore
+  parser?: "flow" | "babel" | "babel-flow" | "babel-ts" | "typescript" | "acorn" | "espree" | "meriyah" | "css" | "less" | "scss" | "json" | "jsonc" | "json5" | "json-stringify" | "graphql" | "markdown" | "mdx" | "vue" | "yaml" | "glimmer" | "html" | "angular" | "lwc"; // prettier-ignore
   plugins?: string[];
   printWidth?: number;
   proseWrap?: "always" | "never" | "preserve";

--- a/test/__tests__/__snapshots__/early-exit.js.snap
+++ b/test/__tests__/__snapshots__/early-exit.js.snap
@@ -53,7 +53,7 @@ exports[`show usage with --help (stdout) 1`] = `
     --object-wrap <preserve|collapse>
                               How to wrap object literals
                               Defaults to "preserve"
-    --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
+    --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                               Which parser to use
     --print-width <int>       The line length where Prettier will try wrap
                               Defaults to "80"

--- a/test/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/test/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`show external options with \`--help\` 1`] = `
-"    --parser <flow,babel,babel-flow,babel-ts,typescript,acorn,espree,meriyah,css,less,scss,json,json5,json-stringify,graphql,markdown,mdx,vue,yaml,glimmer,html,angular,lwc,foo-parser>
+"    --parser <flow,babel,babel-flow,babel-ts,typescript,acorn,espree,meriyah,css,less,scss,json,json5,jsonc,json-stringify,graphql,markdown,mdx,vue,yaml,glimmer,html,angular,lwc,foo-parser>
     --foo-string <value>      foo description
                               Defaults to "bar""
 `;

--- a/test/__tests__/__snapshots__/plugin-options.js.snap
+++ b/test/__tests__/__snapshots__/plugin-options.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`show external options with \`--help\` 1`] = `
-"    --parser <flow,babel,babel-flow,babel-ts,typescript,acorn,espree,meriyah,css,less,scss,json,json5,json-stringify,graphql,markdown,mdx,vue,yaml,glimmer,html,angular,lwc,foo-parser>
+"    --parser <flow,babel,babel-flow,babel-ts,typescript,acorn,espree,meriyah,css,less,scss,json,json5,jsonc,json-stringify,graphql,markdown,mdx,vue,yaml,glimmer,html,angular,lwc,foo-parser>
     --foo-option <bar|baz>    foo description
                               Defaults to "bar""
 `;


### PR DESCRIPTION
- Missing `jsonc` parser newly added in v3.2.0.
- Remove support for `.prettierrc.jsonc` configure file, we never support it