### PR TITLE
Switch `prettier/standalone` import to namespace

### DIFF
--- a/src/prettier_serial.ts
+++ b/src/prettier_serial.ts
@@ -1,6 +1,6 @@
 import { readFile, writeFile } from "atomically";
 import process from "node:process";
-import prettier from "prettier/standalone";
+import * as prettier from "prettier/standalone";
 import { getPluginsOrExit, getPluginsBuiltin, resolve } from "./utils.js";
 import type { ContextOptions, LazyFormatOptions, PluginsOptions } from "./types.js";
 


### PR DESCRIPTION
Default export only exists in production, and we plan to remove it in future.

Swtich the import style to unblock https://github.com/prettier/prettier/pull/17396