### PR TITLE
test: strip slashes in snapshots

### DIFF
--- a/test/utils.js
+++ b/test/utils.js
@@ -106,6 +106,12 @@ function getNormalizedOutput(output, options) {
   // the cwd is replaced with $CWD for snapshotting purposes
   const { cwd } = options;
   output = output.replaceAll(cwd, "$CWD");
+  // We do this because snapshots on windows will have backslashes, and on
+  // linux will have forward slashes. Since we don't care right now about
+  // slashes, we can replace them.
+  // If we ever need to assert that something contained a backslash, remove
+  // this and make it configurable or do it only for paths
+  output = output.replaceAll("\\", "/");
   return output;
 }
 


### PR DESCRIPTION
For windows, tests will fail since the output contains `$CWD\path` rather than `$CWD/path`.

We can just replace all backslashes for now and make Windows happy.

If we ever need to assert something contains a backslash, do a more complex solution here.