### PR TITLE
Keep unknown keys in `overrides[].options`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -656,7 +656,7 @@ function normalizePrettierOptions(options: unknown, folderPath: string): Prettie
       const filesPositive = castArray(overrideRaw.files);
       const filesNegative = "filesNegative" in overrideRaw && (isString(overrideRaw.filesNegative) || (isArray(overrideRaw.filesNegative) && overrideRaw.filesNegative.every(isString))) ? castArray(overrideRaw.filesNegative) : []; // prettier-ignore
       const folder = folderPath;
-      const options = normalizeFormatOptions(overrideRaw.options);
+      const options = { ...overrideRaw.options, ...normalizeFormatOptions(overrideRaw.options) };
       overrides.push({ filesPositive, filesNegative, folder, options });
     }
   }


### PR DESCRIPTION
Related to an issue raised in https://github.com/prettier/prettier-cli/issues/70

Current behaviour only keeps the known configuration directives in the `options` object of an `override`. This implicitly drops any plugin configuration, while upstream prettier (legacy CLI) keeps them.

This PR copies the whole `options` object and only normalizes the know directives — similar to how the top-level configuration object is constructed. This now allows overriding plugin configuration for specific files.

Let me know if this isn't the way we want to go or if plugin options should be handled more strictly.