### PR TITLE
Ensure config passed via `--config-path` is resolved

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,8 @@ type Prettier = typeof import("./prettier_serial.js");
 
 type PrettierConfig = FormatOptions;
 
+type PrettierConfigResolver = (filePath: string) => PrettierConfig;
+
 type PrettierConfigWithOverrides = PrettierConfig & {
   overrides?: {
     filesPositive: string[];
@@ -108,6 +110,7 @@ export type {
   PluginsOptions,
   Prettier,
   PrettierConfig,
+  PrettierConfigResolver,
   PrettierConfigWithOverrides,
   PrettierPlugin,
   PromiseMaybe,


### PR DESCRIPTION
Normalize the configuration that is passed via the `--config-path` cli option on load (previously only the automatically loaded files were normalized).

Resolve the manually loaded config against the current file to take the `overrides` directives into account.

This should fix the underlying issue raised in #70.

---

I am open for suggestion on the naming of these functions and types.