### PR TITLE
fix: use `fastRelativePath` when processing ignore paths

### DIFF
--- a/src/config_ignore.ts
+++ b/src/config_ignore.ts
@@ -2,7 +2,7 @@ import fastIgnore from "fast-ignore";
 import fs from "node:fs/promises";
 import path from "node:path";
 import Known from "./known.js";
-import { fastJoinedPath, fastRelativeChildPath, isString, isUndefined, memoize, noop, someOf, zipObjectUnless } from "./utils.js";
+import { fastJoinedPath, fastRelativePath, isString, isUndefined, memoize, noop, someOf, zipObjectUnless } from "./utils.js";
 import type { Ignore, PromiseMaybe } from "./types.js";
 
 const getIgnoreContent = (folderPath: string, fileName: string): PromiseMaybe<string | undefined> => {
@@ -27,7 +27,7 @@ const getIgnoresContentMap = async (foldersPaths: string[], filesNames: string[]
 const getIgnoreBy = (folderPath: string, filesContents: string[]): Ignore => {
   const ignore = fastIgnore(filesContents);
   return (filePath: string): boolean => {
-    const fileRelativePath = fastRelativeChildPath(folderPath, filePath);
+    const fileRelativePath = fastRelativePath(folderPath, filePath);
     return !!fileRelativePath && ignore(fileRelativePath);
   };
 };


### PR DESCRIPTION
An ignore path can be relative.

For example:

- ignore folder can be `/foo/configs`
- file can be `/foo/src/index.ts`
- the ignore file can be `/foo/configs/.prettierignore`
- the ignore contents can be `../src/index.ts`

This means we end up doing:

```ts
// does not fall back to path.relative
fastRelativeChildPath('/foo/configs', '/foo/src/index.ts');
// undefined
```

Which fails since we actually need `fastRelativePath`:

```ts
// falls back to path.relative
fastRelativePath('/foo/configs', '/foo/src/index.ts');
// ../src/index.ts
```

Fixes #82
