### PR TITLE
Destruct `parse` from `import('smol-toml')`

### DIFF
--- a/src/config_prettier.ts
+++ b/src/config_prettier.ts
@@ -46,8 +46,8 @@ const Loaders = {
   },
   toml: async (filePath: string): Promise<unknown> => {
     const fileContent = fs.readFileSync(filePath, "utf8");
-    const toml = await import("smol-toml");
-    return toml.parse(fileContent);
+    const {parse} = await import("smol-toml");
+    return parse(fileContent);
   },
   yaml: async (filePath: string): Promise<unknown> => {
     const yaml = (await import("js-yaml")).default;


### PR DESCRIPTION
ESBuild seems not able to tree-shake without this change, it's already done in Prettier build script.

https://github.com/prettier/prettier/blob/5e82e9a8234cf30800a1891c20a51e9d05262d80/scripts/build/config.js#L854-L861