### PR TITLE
ci: declare contents:read on typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read`. The job checks out the repo and runs the linter / format checker; nothing here calls a GitHub API beyond the initial checkout, and the action surfaces failures as the workflow's own check status.

This is supply-chain hygiene anchored in CVE-2025-30066 - the March 2025 `tj-actions/changed-files` compromise - where a tampered third-party action read `GITHUB_TOKEN` out of workflow logs and the blast radius equalled whatever scope was issued. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is what OpenSSF Scorecard's Token-Permissions check credits. Small files like this one are the easy place to start the org-wide hygiene work.

YAML validated locally with `yaml.safe_load`.
